### PR TITLE
feat: add LeMaterial Bulk and Traj

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Want to add a new dataset or improve metadata?
 | [QCML](https://zenodo.org/records/14859804) | Small molecules consisting of up to 8 heavy atoms | 14.7B Semi-empirical + 33.5M DFT calculations | Computational | TFDS | CC BY-NC 4.0 | Open |
 | [QM9](http://quantum-machine.org/datasets/) | Small organic molecules | 134k molecules with quantum properties | Experimental | SDF/CSV | CC BY 4.0 | Open |
 | [QM7/QM7b](http://quantum-machine.org/datasets/) | Small molecules | 7k molecules with atomization energies | Experimental | SDF/CSV | CC BY 4.0 | Open |
-
+| [LeMat-Bulk](https://huggingface.co/datasets/LeMaterial/LeMat-Bulk) | Inorganic materials (bulk) | 6.7M structures (5.9M materials) | Computational | HuggingFace Dataset | CC BY 4.0 | Open |
+| [LeMat-Traj](https://huggingface.co/datasets/LeMaterial/LeMat-Traj) | Inorganic materials (trajectories) | 113M structures | Computational | HuggingFace Dataset | CC BY 4.0 | Open |
 
 
 


### PR DESCRIPTION
Added two datasets – LeMat-Bulk and -Traj – to the README.md (domain: Computational)   
   - Domain Materials science
   - Type (`Computational`, `Experimental`, `Literature-mined`)
   - Size 6-113M rows
   - Access (Open/Restricted/Proprietary)
   - Format (JSON, CSV, CIF, HDF5, SMILES, etc.) – **notes as HuggingFace Dataset. Should i change to JSON?**
   - License CC BY 4.0
   - Access Links https://huggingface.co/datasets/LeMaterial/LeMat-Bulk and https://huggingface.co/datasets/LeMaterial/LeMat-Traj
   - Notes or Use Cases Inorganic materials (bulk and trajectories) -- parsed from open source databases such as Materials Project, Alexandria, OQMD

Please let me know if something should be adapted for this contribution. Thank you !